### PR TITLE
fix(cd): diff against merge commit's first parent in paths-filter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          base: HEAD~1
           filters: |
             realtime:
               - 'apps/realtime/**'


### PR DESCRIPTION
## Summary
- `changes` job's paths-filter step fell back to `git log -1 --name-status` (no `base` set, and `workflow_run` events carry no `before`/`after` SHA), which shows 0 files for a merge commit by default, so `build-and-push` was skipped on every push to master regardless of what actually changed.
- Pin `base: HEAD~1` so it diffs against the previous master tip explicitly instead of relying on that fallback.